### PR TITLE
updating workflows to most recent versions

### DIFF
--- a/.github/auto-release-config.yml
+++ b/.github/auto-release-config.yml
@@ -1,0 +1,54 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
+version-resolver:
+  major:
+    labels:
+    - 'major'
+  minor:
+    labels:
+    - 'minor'
+    - 'enhancement'
+  patch:
+    labels:
+    - 'auto-update'
+    - 'patch'
+    - 'fix'
+    - 'bugfix'
+    - 'bug'
+    - 'hotfix'
+    - 'no-release'
+  default: 'minor'
+
+categories:
+- title: '🚀 Enhancements'
+  labels:
+  - 'enhancement'
+  - 'patch'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+  - 'hotfix'
+- title: '🤖 Automatic Updates'
+  labels:
+  - 'auto-update'
+
+change-template: |
+  <details>
+    <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
+
+    $BODY
+  </details>
+
+template: |
+  $CHANGES
+
+replacers:
+# Remove irrelevant information from Renovate bot
+- search: '/(?<=---\s)\s*^#.*(Renovate configuration|Configuration)(?:.|\n)*?This PR has been generated .*/gm'
+  replace: ''
+# Remove Renovate bot banner image
+- search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'
+  replace: ''

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -3,11 +3,18 @@ on:
   schedule:
   # Update context.tf nightly (assuming your time zone is GMT-7)
   - cron:  '0 7 * * *'
+  workflow_dispatch:
 
 jobs:
   auto-context:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cloudposse/github-action-terraform-auto-context@main
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+    # For development reasons, this action is pinned to the `main` branch.
+    # However, we recommend that you choose a specific release to pin to.
+    # Consult https://github.com/cloudposse/github-action-auto-context/releases for a list of available releases.
+    uses: cloudposse/github-action-terraform-auto-context/.github/workflows/auto-context-reusable.yml@main
+    with:
+      # Name of branch to commit updated context.tf to
+      branch-name: auto-update/context.tf
+      # GitHub username to use for automated commits (should be a real GitHub user)
+      bot-name: cloudpossebot
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -8,12 +8,17 @@ on:
 
 jobs:
   auto-format:
+    # For development reasons, this action is pinned to the `main` branch.
+    # However, we recommend that you choose a specific release to pin to.
+    # Consult https://github.com/cloudposse/github-action-auto-format/releases for a list of available releases.
+
     # only run on pull requests so long as they don't come from forks
     if: ${{ !( (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository) ) }}
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cloudposse/github-action-auto-format@main
-      with:
-        script-names: readme,github_format,terraform_format
-        workflow-token: ${{ secrets.TOKEN_WITH_WORKFLOWS_PERMISSION }}
-        bot-name: cloudpossebot
+    uses: cloudposse/github-action-auto-format/.github/workflows/auto-format-reusable.yml@review-branch
+    with:
+      # Delete "format-tasks:" values as desired to limit the scope of the overall auto-formatting task.
+      format-tasks: "[\"readme\", \"github\", \"terraform\"]"
+      # GitHub username to use for automated commits (should be a real GitHub user)
+      bot-name: cloudpossebot
+    secrets:
+      workflow-token: ${{ secrets.TOKEN_WITH_WORKFLOWS_PERMISSION }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,3 +1,8 @@
+# Please see
+# https://github.com/cloudposse/github-action-auto-release/blob/main/README.md
+# and
+# https://github.com/release-drafter/release-drafter
+# for information on customizing this action's behavior.
 name: "auto-release"
 on:
   push:
@@ -5,13 +10,16 @@ on:
       - main
       - master
       - production
+  workflow_dispatch:
 
 jobs:
   auto-release:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cloudposse/github-action-auto-release@main
-      with:
-        prerelease: false
-        publish: true
-        token: ${{ secrets.GITHUB_TOKEN }}
+    # For development reasons, this action is pinned to the `main` branch.
+    # However, we recommend that you choose a specific release to pin to.
+    # Consult https://github.com/cloudposse/github-action-auto-release/releases for a list of available releases.
+    uses: cloudposse/github-action-auto-release/.github/workflows/auto-release-reusable.yml@main
+    with:
+      prerelease: false
+      publish: true
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-terraform.yml
+++ b/.github/workflows/ci-terraform.yml
@@ -2,27 +2,24 @@ name: "ci-terraform"
 on:
   issue_comment:
     types: [created]
-  pull_request_target:
+  pull_request:
     types: [opened, synchronized, reopened]
 
 jobs:
+  # Handle common commands and tests, including when triggered via chatops
   ci-terraform:
     # only run on pull requests so long as they don't come from forks
     if: ${{ !( (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name != github.repository) ) }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: "Handle common commands and tests, including when triggered via chatops"
-        uses: cloudposse/github-action-ci-terraform@main
-        if: always()
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
-          CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
-          DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
-          OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
-          SPOTINST_ACCOUNT: ${{ secrets.SPOTINST_ACCOUNT }}
-          SPOTINST_TOKEN: ${{ secrets.SPOTINST_TOKEN }}
-          TFE_TOKEN: ${{ secrets.TFE_TOKEN }}
+    uses: cloudposse/github-action-ci-terraform/.github/workflows/ci-terraform-reusable.yml@javascript-reorganization
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      CLOUDFLARE_EMAIL: ${{ secrets.CLOUDFLARE_EMAIL }}
+      CLOUDFLARE_API_KEY: ${{ secrets.CLOUDFLARE_API_KEY }}
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
+      DD_APP_KEY: ${{ secrets.DD_APP_KEY }}
+      OPSGENIE_API_KEY: ${{ secrets.OPSGENIE_API_KEY }}
+      SPOTINST_ACCOUNT: ${{ secrets.SPOTINST_ACCOUNT }}
+      SPOTINST_TOKEN: ${{ secrets.SPOTINST_TOKEN }}
+      TFE_TOKEN: ${{ secrets.TFE_TOKEN }}

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,12 +1,12 @@
 name: "validate-codeowners"
 on:
   pull_request_target:
-  workflow_dispatch:
 
 jobs:
   validate-codeowners:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: cloudposse/github-action-validate-codeowners@main
-      with:
-        token: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN_PUBLIC }}
+    # For development reasons, this action is pinned to the `main` branch.
+    # However, we recommend that you choose a specific release to pin to.
+    # Consult https://github.com/cloudposse/github-action-validate-codeowners/releases for a list of available releases.
+    uses: cloudposse/github-action-validate-codeowners/.github/workflows/validate-codeowners-reusable.yml@main
+    secrets:
+      token: ${{ secrets.CODEOWNERS_VALIDATOR_TOKEN_PUBLIC }}


### PR DESCRIPTION
## what
* Updating workflows referencing `cloudposse/github-action-*` actions to the most recent version found in those actions' documentation. (Usually, the documentation workflows for our actions are just found in `.github/workflows.)

## why
* This ensures that, when we disseminate the workflows from this repo (via `github-action-auto-format`), we are disseminating the most recent versions, which are guaranteed to work.