### PR TITLE
Update github output syntax

### DIFF
--- a/workflow-templates/auto-readme.yml
+++ b/workflow-templates/auto-readme.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           default_branch=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name)
-          printf "::set-output name=defaultBranch::%s\n" "${default_branch}"
+          echo "defaultBranch=${default_branch}\n" >> $GITHUB_OUTPUT
           printf "defaultBranchRef.name=%s\n" "${default_branch}"
 
       - name: Update readme


### PR DESCRIPTION
## what
Update github output syntax

## why
Following github docs

## references
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/