### PR TITLE
Fix repo-banner workflow pinning to main

### DIFF
--- a/.github/workflows/repo-banner.yml
+++ b/.github/workflows/repo-banner.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions/checkout@v3
       with:
         repository: '${{ steps.metadata.outputs.owner_login }}/.github'
-        ref: 'fix-banner-workflow'
+        ref: 'main'
         path: 'github'
 
     - name: Symlink ${{github.workspace}} to `github/`


### PR DESCRIPTION
## what
* pin to main

## why
* Accidentally merged while pinning to a branch for testing