### PR TITLE
Do not require README_INCLUDES to be defined

### DIFF
--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -1,5 +1,5 @@
-{{- defineDatasource "config" .Env.README_YAML | regexp.Replace ".*" "" -}}
-{{- defineDatasource "includes" .Env.README_INCLUDES | regexp.Replace ".*" "" -}}
+{{- defineDatasource "config" .Env.README_YAML -}}
+{{- defineDatasource "includes" (env.Getenv "README_INCLUDES") -}}
 {{- $deprecated := has (ds "config") "deprecated" }}
 <!-- markdownlint-disable -->
 {{- if $deprecated }}


### PR DESCRIPTION
## what

- Do not require `README_INCLUDES` environment variable to be defined

## why

- https://github.com/cloudposse/build-harness/pull/368 removed it since it was badly defined

## references

- https://github.com/cloudposse/build-harness/pull/368
- https://github.com/cloudposse/build-harness/pull/100
