### PR TITLE
Update node16 actions to node20 versions

### DIFF
--- a/.github/workflows/org-banner.yml
+++ b/.github/workflows/org-banner.yml
@@ -17,7 +17,7 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Generate banner image
       id: screenshot
@@ -30,7 +30,7 @@ jobs:
         viewportHeight: 370
         omitBackground: true
 
-    - uses: stefanzweifel/git-auto-commit-action@v4
+    - uses: stefanzweifel/git-auto-commit-action@v5
       name: Commit artifact
       id: auto-commit
       env:

--- a/.github/workflows/repo-banner.yml
+++ b/.github/workflows/repo-banner.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Fetch repo metadata
       id: metadata
@@ -27,7 +27,7 @@ jobs:
 
     - name: Checkout ${{ steps.metadata.outputs.owner_login}}/.github
       if: steps.metadata.outputs.repository_name != '.github'
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: '${{ steps.metadata.outputs.owner_login }}/.github'
         ref: 'main'
@@ -117,7 +117,7 @@ jobs:
         viewportHeight: 320
         omitBackground: true
 
-    - uses: stefanzweifel/git-auto-commit-action@v4
+    - uses: stefanzweifel/git-auto-commit-action@v5
       name: Commit artifact
       id: auto-commit
       env:

--- a/workflow-templates/auto-readme.yml
+++ b/workflow-templates/auto-readme.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Find default branch name
         id: defaultBranch

--- a/workflow-templates/test-github-action.yml
+++ b/workflow-templates/test-github-action.yml
@@ -20,7 +20,7 @@ jobs:
     continue-on-error: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: ./
         id: current


### PR DESCRIPTION
## what

- Update `node16` actions to `node20` versions
  - `actions/checkout` -> v4
  - `stefanzweifel/git-auto-commit-action` -> v5

## why

- Node16 support is deprecated

## references

- https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

