### PR TITLE
Prevent looping on triage label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -437,6 +437,8 @@ pull_request_rules:
       - and: *is_open
       - and: *not_a_bot
       - '#label=0'
+      # When the PR is approved, the triage label is removed. Do not add it back
+      - '#approved-reviews-by=0'
       - or:
         - created-at > 5 minutes ago
         - commits[*].date_committer > 5 minutes ago


### PR DESCRIPTION
## what

- Do not add triage label to PR after it has been removed due to being approved

## why

- Remove infinite loop

## references

- https://github.com/cloudposse/terraform-aws-cloudfront-s3-cdn/pull/295