### PR TITLE
Allow release access for tags

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -54,6 +54,8 @@ environments:
       custom_branches:
         - main
         - release/**
+      custom_tags:
+        - *.*.*
   - name: security
     deployment_branch_policy:
       custom_branches:


### PR DESCRIPTION
## what
* Allow release access for tags

## why
* To solve `release-branches` and `release tagger` workflows
https://github.com/cloudposse/terraform-example-module/actions/runs/8545707656
