### PR TITLE
Use self-hosted runners for gorelease

### DIFF
--- a/.github/workflows/shared-go-auto-release.yml
+++ b/.github/workflows/shared-go-auto-release.yml
@@ -7,7 +7,7 @@ on:
         description: "Overrides job runs-on setting (json-encoded list)"
         type: string
         required: false
-        default: 'self-hosted-large'
+        default: '["self-hosted-large"]'
       prerelease:
         description: "Boolean indicating whether this release should be a prerelease"
         required: false


### PR DESCRIPTION
## what
* Use self-hosted runners for gorelease

## why
* Solve out of space

## references
* https://github.com/cloudposse/terraform-provider-awsutils/actions/runs/8799247307/job/24148159056
