### PR TITLE
[share github action workflow] Fix default ref

### DIFF
--- a/.github/workflows/shared-github-action.yml
+++ b/.github/workflows/shared-github-action.yml
@@ -16,7 +16,7 @@ on:
       ref:
         description: "The fully-formed ref of the branch or tag that triggered the workflow run"
         required: false
-        default: ${{ github.ref }}
+        default: ${{ github.sha }}
         type: string
       tests-prefix:
         description: "Workflows file name prefix to run as tests"


### PR DESCRIPTION
## what
*  Fix default ref for shared github action workflow

## why
* Allow to trigger test workflows 

## References
* https://github.com/cloudposse/github-action-test-action/actions/runs/9133786143/job/25118007992