### PR TITLE
fix: Point Shared Workflows to `main`

### DIFF
--- a/.github/workflows/shared-terraform-module.yml
+++ b/.github/workflows/shared-terraform-module.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   ci-terraform:
-    uses: cloudposse/github-actions-workflows/.github/workflows/ci-terraform.yml@shared-workflows
+    uses: cloudposse/github-actions-workflows/.github/workflows/ci-terraform.yml@main
     name: "CI"
     with:
       # Workaround for https://github.com/community/community/discussions/9099
@@ -28,7 +28,7 @@ jobs:
       runs-on: ${{ inputs.runs-on }}
 
   ci-readme:
-    uses: cloudposse/github-actions-workflows/.github/workflows/ci-readme.yml@shared-workflows
+    uses: cloudposse/github-actions-workflows/.github/workflows/ci-readme.yml@main
     name: "Readme"
     if: ${{ github.event_name == 'push' }}
     with:
@@ -36,7 +36,7 @@ jobs:
     secrets: inherit
 
   ci-codeowners:
-    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@shared-workflows
+    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@main
     name: "CI"
     with:
       is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}


### PR DESCRIPTION
## what
- Update workflow action references to use `main` branch

## why
- The previously mentioned branch does not exist anymore. It was merged with https://github.com/cloudposse/github-actions-workflows/pull/117

## references
- Example of failing module: https://github.com/cloudposse/terraform-aws-managed-prometheus/actions/runs/9292957421

```console
[Invalid workflow file: .github/workflows/branch.yml#L24](https://github.com/cloudposse/terraform-aws-managed-prometheus/actions/runs/9292957421/workflow)
error parsing called workflow
".github/workflows/branch.yml"
-> "cloudposse/.github/.github/workflows/shared-terraform-module.yml@main" (source branch with sha:a7920175625a9e55449656baafda1bd2a82603ba)
--> "cloudposse/github-actions-workflows/.github/workflows/ci-terraform.yml@shared-workflows"
: failed to fetch workflow: reference to workflow should be either a valid branch, tag, or commit
```
