### PR TITLE
Restrict role that can run terratest

### DIFF
--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -21,11 +21,16 @@ defaults:
 jobs:
   pr:
     name: PR Info
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/terratest') }}
+    # https://docs.github.com/en/graphql/reference/enums#commentauthorassociation
+    if: ${{ github.event.issue.pull_request && 
+            contains(github.event.comment.body, '/terratest') &&
+            github.event.issue.state == 'open' &&
+            ( github.event.comment.author_association == 'OWNER' ||
+              github.event.comment.author_association == 'COLLABORATOR' ||
+              github.event.comment.author_association == 'MEMBER' )
+        }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
-      - run: |-
-          echo "${{ toJSON(github.event) }}"
       - uses: cloudposse-github-actions/get-pr@v2
         id: pr
         with:
@@ -330,7 +335,7 @@ jobs:
   finalize:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     needs: [terratest, pr]
-    if: ${{ always() && github.event.issue.pull_request && contains(github.event.comment.body, '/terratest') }}
+    if: ${{ always() && needs.pr.result != 'skipped' }}
     steps:
       - shell: bash
         id: status

--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -24,6 +24,8 @@ jobs:
     if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/terratest') }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
+      - run: |-
+          echo "${{ fromJSON(github.event.issue.pull_request) }}"
       - uses: cloudposse-github-actions/get-pr@v2
         id: pr
         with:

--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - run: |-
-          echo "${{ fromJSON(github.event.issue.pull_request) }}"
+          echo "${{ fromJSON(github.event.issue) }}"
       - uses: cloudposse-github-actions/get-pr@v2
         id: pr
         with:

--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - run: |-
-          echo "${{ toJSON(github.event.issue) }}"
+          echo "${{ toJSON(github.event) }}"
       - uses: cloudposse-github-actions/get-pr@v2
         id: pr
         with:

--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     steps:
       - run: |-
-          echo "${{ fromJSON(github.event.issue) }}"
+          echo "${{ toJSON(github.event.issue) }}"
       - uses: cloudposse-github-actions/get-pr@v2
         id: pr
         with:


### PR DESCRIPTION
## what
* Restrict `terratest` run only to `OWNER`, `MEMBER`, `COLLOBORATOR`
* Allow `terratest` run only for open PR

## why
* Avoid random users to run `terratest` (because of cost and security reason)
* Do not run tests for closed PRs

## references
* https://docs.github.com/en/graphql/reference/enums#commentauthorassociation