### PR TITLE
Fix release changelog space issue

### DIFF
--- a/.github/auto-release-hotfix.yml
+++ b/.github/auto-release-hotfix.yml
@@ -38,7 +38,7 @@ categories:
 change-template: |
   <details>
     <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
-    $BODY
+  $BODY
   </details>
 template: |
   $CHANGES

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -39,7 +39,7 @@ categories:
 change-template: |
   <details>
     <summary>$TITLE @$AUTHOR (#$NUMBER)</summary>
-    $BODY
+  $BODY
   </details>
 template: |
   $CHANGES


### PR DESCRIPTION
## what
* Fix release changelog space issue

![CleanShot 2024-10-01 at 12 27 42@2x](https://github.com/user-attachments/assets/2d42740a-1d5d-4990-94ac-eb49bdfe4c32)

## why
* Have nice changelog

## references
* https://github.com/cloudposse/terraform-aws-components/pull/1117/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR10