### PR TITLE
Use github app for codeowners validation

### DIFF
--- a/.github/workflows/shared-terraform-module.yml
+++ b/.github/workflows/shared-terraform-module.yml
@@ -7,10 +7,6 @@ on:
         type: string
         required: false
         default: '["ubuntu-latest"]'
-    secrets:
-      REPO_ACCESS_TOKEN:
-        description: "GitHub API token"
-        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,13 +32,12 @@ jobs:
     secrets: inherit
 
   ci-codeowners:
-    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@main
+    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@codeowners-github-app
     name: "CI"
     with:
       is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
       runs-on: ${{ inputs.runs-on }}
-    secrets:
-      github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
+    secrets: inherit
 
   ci-labels:
     runs-on: ${{ fromJSON(inputs.runs-on) }}

--- a/.github/workflows/shared-terraform-module.yml
+++ b/.github/workflows/shared-terraform-module.yml
@@ -32,7 +32,7 @@ jobs:
     secrets: inherit
 
   ci-codeowners:
-    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@codeowners-github-app
+    uses: cloudposse/github-actions-workflows/.github/workflows/ci-codeowners.yml@main
     name: "CI"
     with:
       is_fork: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}


### PR DESCRIPTION
## what
* Use the GitHub app for code owners validation

## why
* Get rid of PAT for security reasons
* DEV-2144 Create GitHub app for code-owners testing

## references
* https://linear.app/cloudposse/issue/DEV-2144/create-github-app-for-code-owners-testing
