### PR TITLE
Fix readme template

### DIFF
--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -1,5 +1,5 @@
 {{- defineDatasource "config" .Env.README_YAML -}}
-{{- defineDatasource "includes" (env.Getenv "README_INCLUDES") -}}
+{{- defineDatasource "includes" (env.Getenv "README_INCLUDES" | default "./") -}}
 {{- $deprecated := has (ds "config") "deprecated" }}
 {{- $is_terraform := (strings.Contains "terraform-" ((ds "config").github_repo))  -}}
 {{- $utm_link := printf "%%s?utm_source=%s&utm_medium=%s&utm_campaign=%s&utm_content=%s" "github" "readme" (ds "config").github_repo "%s" -}}


### PR DESCRIPTION
## what
* Added explicit default value for `README_INCLUDES` environment variables

## why
* Starting from [gomplate `4.2.0`](https://github.com/hairyhenderson/gomplate/releases/tag/v4.2.0) includes required implicit definition starting with "./" or "/"
 
## references
* https://sweetops.slack.com/archives/CUJPCP1K6/p1731416487743859
* https://github.com/cloudposse/terraform-aws-alb/actions/runs/11795616491/job/32869718771
* https://github.com/hairyhenderson/gomplate/pull/2255
