### PR TITLE
Do not remove google-sdk and hhvm

### DIFF
--- a/.github/workflows/shared-go-auto-release.yml
+++ b/.github/workflows/shared-go-auto-release.yml
@@ -170,7 +170,7 @@ jobs:
           sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^llvm-.*'
           sudo apt-get remove -y 'php.*'
-          sudo apt-get remove -y --ignore-missing azure-cli google-cloud-sdk hhvm google-chrome-stable firefox powershell mono-devel
+          sudo apt-get remove -y google-chrome-stable firefox powershell mono-devel
           sudo apt-get autoremove -y
           sudo apt-get clean
           rm -rf /usr/share/dotnet/


### PR DESCRIPTION
## what
* Do not remove google-sdk and hhvm

## why
* Github public runners do not have it pre-installed
