### PR TITLE
Move GHA runners to public subnets

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -82,7 +82,7 @@ runners:
     disk: default
     spot: price-capacity-optimized
     retry: when-interrupted
-    private: true
+    private: false
     ssh: false
     tags:
       - "gha-runner:runs-on/default"


### PR DESCRIPTION
## what

- Move GitHub Action Runners to public subnets

## why

- Save money on NAT and network traffic charges

