### PR TITLE
Go releaser use default parallelism

### DIFF
--- a/.github/workflows/shared-go-auto-release.yml
+++ b/.github/workflows/shared-go-auto-release.yml
@@ -215,7 +215,7 @@ jobs:
         with:
           workdir: source
           version: latest
-          args: release --config ${{ steps.go-releaser-config.outputs.path }} --clean --parallelism 2 --timeout 180m
+          args: release --config ${{ steps.go-releaser-config.outputs.path }} --clean --timeout 180m
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           GITHUB_TOKEN: ${{ steps.github-app.outputs.token }}


### PR DESCRIPTION
## what
* Go releaser use default parallelism

## why
* Better utilize CPU for runs-on runners