### PR TITLE
Do not create empty releases

### DIFF
--- a/.github/workflows/shared-auto-release.yml
+++ b/.github/workflows/shared-auto-release.yml
@@ -61,6 +61,10 @@ on:
 permissions: {}
 
 jobs:
+  exists:
+    runs-on: ${{ fromJSON(inputs.runs-on) }}
+    
+
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment: release
@@ -111,7 +115,7 @@ jobs:
                 latest: false
 
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: cloudposse/github-action-auto-release@v2
+      - uses: cloudposse/github-action-auto-release@test-auto-release-action
         id: drafter
         with:
           token: ${{ steps.github-app.outputs.token }}

--- a/.github/workflows/shared-auto-release.yml
+++ b/.github/workflows/shared-auto-release.yml
@@ -111,7 +111,7 @@ jobs:
                 latest: false
 
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: cloudposse/github-action-auto-release@test-auto-release-action
+      - uses: cloudposse/github-action-auto-release@v3
         id: drafter
         with:
           token: ${{ steps.github-app.outputs.token }}

--- a/.github/workflows/shared-auto-release.yml
+++ b/.github/workflows/shared-auto-release.yml
@@ -61,10 +61,6 @@ on:
 permissions: {}
 
 jobs:
-  exists:
-    runs-on: ${{ fromJSON(inputs.runs-on) }}
-    
-
   release:
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment: release

--- a/.github/workflows/shared-go-auto-release.yml
+++ b/.github/workflows/shared-go-auto-release.yml
@@ -68,7 +68,7 @@ permissions: {}
 
 jobs:
   draft:
-    uses: cloudposse/.github/.github/workflows/shared-auto-release.yml@skip-no-changes
+    uses: cloudposse/.github/.github/workflows/shared-auto-release.yml@main
     with:
       publish: false
       summary-enabled: false

--- a/.github/workflows/shared-go-auto-release.yml
+++ b/.github/workflows/shared-go-auto-release.yml
@@ -68,7 +68,7 @@ permissions: {}
 
 jobs:
   draft:
-    uses: cloudposse/.github/.github/workflows/shared-auto-release.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-auto-release.yml@skip-no-changes
     with:
       publish: false
       summary-enabled: false


### PR DESCRIPTION
## what
* Pin `cloudposse/github-action-auto-release` to  v3.0.0 

## why
* Do not issue new releases if there are any for the current commit 