### PR TITLE
Temporary use cloudposse/github-action-auto-release v2

### DIFF
--- a/.github/workflows/shared-auto-release.yml
+++ b/.github/workflows/shared-auto-release.yml
@@ -111,7 +111,7 @@ jobs:
                 latest: false
 
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: cloudposse/github-action-auto-release@v3
+      - uses: cloudposse/github-action-auto-release@v2
         id: drafter
         with:
           token: ${{ steps.github-app.outputs.token }}


### PR DESCRIPTION
## what
* Temporary use cloudposse/github-action-auto-release v2

## why
* cloudposse/github-action-auto-release v3 have bug

