### PR TITLE
Use cloudposse/github-action-auto-release v3

### DIFF
--- a/.github/workflows/shared-auto-release.yml
+++ b/.github/workflows/shared-auto-release.yml
@@ -111,7 +111,7 @@ jobs:
                 latest: false
 
       # Drafts your next Release notes as Pull Requests are merged into "main"
-      - uses: cloudposse/github-action-auto-release@v2
+      - uses: cloudposse/github-action-auto-release@v3
         id: drafter
         with:
           token: ${{ steps.github-app.outputs.token }}


### PR DESCRIPTION
## what
* Use cloudposse/github-action-auto-release v3

## why
* Do not issue duplicated releases