### PR TITLE
[chatops] Terraform AWS auth token ttl 2 hours

### DIFF
--- a/.github/workflows/shared-terraform-chatops.yml
+++ b/.github/workflows/shared-terraform-chatops.yml
@@ -302,6 +302,8 @@ jobs:
           role-to-assume: ${{ env.AWS_ROLE_TO_ASSUME }}
           role-session-name: "terratest"
           mask-aws-account-id: "no"
+          # 2 hours token ttl
+          role-duration-seconds: "7200"
 
       - name: "Test `examples/complete` with terratest"
         run: |-


### PR DESCRIPTION
## what
* Set chatops Terraform AWS auth token TTL 2 hours

## why
* Solve issue with token expiration when tests runs longer then 1 hour (default)
