### PR TITLE
Allow mergify run terratests

### DIFF
--- a/.github/workflows/shared-access-controller.yml
+++ b/.github/workflows/shared-access-controller.yml
@@ -59,6 +59,7 @@ jobs:
                 - nitrocode
                 - gberenice
                 - RoseSecurity
+                - mergify[bot]
 
       - name: debug
         if: ${{ inputs.debug }}


### PR DESCRIPTION
## what
* Allow mergify run terratests

## why
* To improve auto update PRs review process

## references
* DEV-3127: Make sure /terratest commands are automated on rennovate PRs