### PR TITLE
chore: allow terratest user

### DIFF
--- a/.github/workflows/shared-access-controller.yml
+++ b/.github/workflows/shared-access-controller.yml
@@ -59,6 +59,7 @@ jobs:
                 - nitrocode
                 - gberenice
                 - RoseSecurity
+                - oycyc
                 - mergify[bot]
 
       - name: debug


### PR DESCRIPTION
I think this is the place to add allowing running `/terratest` chatops in the GitHub PR comments? I was just recently added to the contributors org group and I thought that would be it, but seems like this file is the actual source.
![image](https://github.com/user-attachments/assets/07dea5c4-a758-4488-9d30-41fd3a44ebce)
