### PR TITLE
Use atmos to generate readme for GHA

### DIFF
--- a/.github/atmos.github-action.yaml
+++ b/.github/atmos.github-action.yaml
@@ -1,0 +1,9 @@
+docs:
+  generate:
+    readme:
+      base-dir: .
+      input:
+        - "./action.yml"
+        - "./README.yaml"
+      template: "https://raw.githubusercontent.com/cloudposse/.github/refs/heads/main/README.md.gotmpl"
+      output: "./README.md"


### PR DESCRIPTION
## what
* Use Atmos to generate a readme for GHA

## why
* Build-harness is deprecated