### PR TITLE
Rollback readme v0 to build harness

### DIFF
--- a/.github/workflows/shared-readme.yml
+++ b/.github/workflows/shared-readme.yml
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.github-app.outputs.token }}
 
-      - uses: cloudposse-github-actions/readme@v1
+      - uses: cloudposse-github-actions/readme@v0
         with:
           token: ${{ steps.github-app.outputs.token }}
           readme_enabled: true


### PR DESCRIPTION
## what
* Rollback readme v0 to build harness

## why
* We need to improve migration script to remove `includes` items from README.yaml