### PR TITLE
Fix shared-terraform-scheduled.yml - support Atmos readme

### DIFF
--- a/.github/workflows/shared-terraform-scheduled.yml
+++ b/.github/workflows/shared-terraform-scheduled.yml
@@ -26,7 +26,7 @@ jobs:
       github_access_token: ${{ secrets.REPO_ACCESS_TOKEN }}
 
   readme:
-    uses: cloudposse/.github/.github/workflows/shared-readme.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-atmos-readme.yml@main
     with:
       runs-on: ${{ inputs.runs-on }}
     secrets: inherit


### PR DESCRIPTION
## what
* Make `shared-terraform-scheduled.yml` use atmos readme

## why
* Fix disapperance of readme after scheduled readme renew 


## References
* https://sweetops.slack.com/archives/CB6GHNLG0/p1748673838383029