### PR TITLE
Fix atmos terraform run

### DIFF
--- a/.github/atmos/terraform-module.yaml
+++ b/.github/atmos/terraform-module.yaml
@@ -19,18 +19,18 @@ docs:
         indent_level: 2
 
 commands:
-- name: test init
+- name: "test-init"
   description: Initialize tests
   steps:
     - "make -C test/src init"
 
-- name: test run
+- name: "test-run"
   description: Run tests
   steps:
     - "cd test/src && go mod tidy"
     - "cd test/src && go test -v -timeout 60m"
 
-- name: test clean
+- name: "test-clean"
   description: Clean tests
   steps:
     - "make -C test/src clean"


### PR DESCRIPTION
## what
* Replace
   * `test init` -> `test-init`
   * `test run` -> `test-run`
   * `test clean` -> `test-clean`
   
## why
* For somehow, when Atmos has multiple commands with a space and the same prefix (eg.:  `test`), none of them work

