### PR TITLE
Fix rebase auto created PRs

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -499,12 +499,14 @@ pull_request_rules:
       - "#commits-behind>=10"
     actions:
       rebase:
+        bot_account: cloudpossebot
 
   - name: rebase pull requests one time when labeled with `rebase`
     conditions:
       - label=rebase
     actions:
-      rebase: {}
+      rebase:
+        bot_account: cloudpossebot
       label:
         remove:
           - rebase


### PR DESCRIPTION
## what
* Specify bot name for mergify rebase configs

## why
* Mergify use PR author for rebase author, but it is impossible to act as github app bot.
   Rebase rule fail for such PRs


## Reference
* DEV-3292 Investigate Mergify dispatch issue not working