### PR TITLE
Auto release use fetch tags

### DIFF
--- a/.github/workflows/shared-go-auto-release.yml
+++ b/.github/workflows/shared-go-auto-release.yml
@@ -68,7 +68,7 @@ permissions: {}
 
 jobs:
   draft:
-    uses: cloudposse/.github/.github/workflows/shared-auto-release.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-auto-release.yml@fetch-tags-only
     with:
       publish: false
       summary-enabled: false
@@ -240,7 +240,7 @@ jobs:
   publish:
     if: ${{ needs.draft.outputs.exists == 'false' }}
     needs: [ goreleaser, draft ]
-    uses: cloudposse/.github/.github/workflows/shared-auto-release.yml@main
+    uses: cloudposse/.github/.github/workflows/shared-auto-release.yml@fetch-tags-only
     with:
       publish: ${{ inputs.publish }}
       prerelease: ${{ inputs.prerelease }}


### PR DESCRIPTION
## what
* Auto release use fetch tags

## why
* Feature releases failed as created from PR

## references
* https://github.com/cloudposse/github-action-auto-release/pull/52