### PR TITLE
Feature release prerelease identifier change

### DIFF
--- a/.github/auto-feature-release.yml
+++ b/.github/auto-feature-release.yml
@@ -1,7 +1,7 @@
 filter-by-commitish: false
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
-prerelease-identifier: 'rc'
+prerelease-identifier: 'xyz'
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
## what
* Feature release prerelease identifier change

## why
* `prerelease identifier` used in version sorting