### PR TITLE
Skip pre releases

### DIFF
--- a/.github/workflows/shared-release-branches.yml
+++ b/.github/workflows/shared-release-branches.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   major-release-tagger:
+    if: ${{ github.event.release.prerelease == false }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment: release
     steps:
@@ -30,6 +31,7 @@ jobs:
           token: ${{ steps.github-app.outputs.token }}
 
   release-branch-manager:
+    if: ${{ github.event.release.prerelease == false }}
     runs-on: ${{ fromJSON(inputs.runs-on) }}
     environment: release
     steps:


### PR DESCRIPTION
## what
* Skip pre releases

## why
* Prevent Cloud Posse Release Branch Manager to Respect Prerelease Flag

## references
* https://linear.app/cloudposse/issue/DEV-3436/prevent-cloud-posse-release-branch-manager-to-respect-prerelease-flag