### PR TITLE
Pin reviewdog action to version 1.22.0

### DIFF
--- a/.github/workflows/shared-ci-terraform.yml
+++ b/.github/workflows/shared-ci-terraform.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Reviewdog suggester
         if: ${{ inputs.suggestions }}
-        uses: reviewdog/action-suggester@v1
+        uses: reviewdog/action-suggester@v1.22.0
         with:
           tool_name: "terraform fmt -recursive"
           cleanup: false


### PR DESCRIPTION
## what
* Pin reviewdog to [v1.22.0](https://github.com/reviewdog/action-suggester/releases/tag/v1.22.0)

## why
* `1.23.0` have regression https://github.com/reviewdog/action-suggester/pull/98

## references
* https://github.com/reviewdog/action-suggester/pull/98
