### PR TITLE
Drop incompatible instance families from runs-on default config

### DIFF
--- a/.github/runs-on.yml
+++ b/.github/runs-on.yml
@@ -45,9 +45,6 @@ runners:
       - c7i.*
       - c7i-flex.*
       - d3.*
-      - hpc6a.*
-      - hpc6id.*
-      - hpc7a.*
       - i3en.*
       - i4i.*
       - i7ie.*
@@ -75,8 +72,6 @@ runners:
       - r7i.*
       - r7iz.*
       - trn1.*
-      - trn1n.*
-      - trn2.*
     cpu: [2, 16]
     ram: [2, 64]
     disk: default


### PR DESCRIPTION
## what
* Remove five instance families from the `default` runner's `family` list in `.github/runs-on.yml`: `hpc6a.*`, `hpc6id.*`, `hpc7a.*`, `trn1n.*`, `trn2.*`.

## why
* These HPC and Trainium families have no instance types that satisfy the configured `cpu: [2, 16]` / `ram: [2, 64]` ranges, so runs-on emitted a `LaunchWarning: Dropped incompatible instance families` on every launch.
* Removing them eliminates the noise and makes the configured list reflect what runs-on can actually schedule. `trn1.*` is kept because it still has matching sizes.

## references
* N/A